### PR TITLE
Fix env var test for local server

### DIFF
--- a/src/DependencyInjection/ConnecthollandUserExtension.php
+++ b/src/DependencyInjection/ConnecthollandUserExtension.php
@@ -109,7 +109,8 @@ class ConnecthollandUserExtension extends Extension implements ExtensionInterfac
         foreach ($resourceOwners as $resourceOwner => $options) {
             foreach ($types as $type) {
                 $envVarName = sprintf('USERBUNDLE_OAUTH_%s_%s', strtoupper($resourceOwner), strtoupper($type));
-                if (getenv($envVarName) !== false) {
+
+                if (getenv($envVarName) !== false || isset($_ENV[$envVarName]) !== false) {
                     $parameterName                         = sprintf('env(%s)', $envVarName);
                     $resourceOwners[$resourceOwner][$type] = $container->resolveEnvPlaceholders($container->getParameter($parameterName), true);
                 }


### PR DESCRIPTION
On local server (symfony server:start) env vars aren't added by putenv and therefor not readable by getenv, symfony does add them to the super global $_ENV. Testing the env var isset is fixed by this change.