### PR TITLE
Only add existing owner maps

### DIFF
--- a/src/DependencyInjection/Compiler/ResourceOwnerMapsPass.php
+++ b/src/DependencyInjection/Compiler/ResourceOwnerMapsPass.php
@@ -25,8 +25,13 @@ final class ResourceOwnerMapsPass implements CompilerPassInterface
 
         $resourceOwnerMaps = [];
         foreach (array_keys($config['firewalls']) as $firewall) {
-            $resourceOwnerMaps[$firewall] = new Reference(sprintf('hwi_oauth.resource_ownermap.%s', $firewall));
+            $definition = sprintf('hwi_oauth.resource_ownermap.%s', $firewall);
+            if ($container->hasDefinition($definition)) {
+                $resourceOwnerMaps[$firewall] = new Reference($definition);
+            }
         }
-        $container->getDefinition(OAuthRouteLoader::class)->replaceArgument('$resourceOwnerMaps', $resourceOwnerMaps);
+        if (!empty($resourceOwnerMaps)) {
+            $container->getDefinition(OAuthRouteLoader::class)->replaceArgument('$resourceOwnerMaps', $resourceOwnerMaps);
+        }
     }
 }


### PR DESCRIPTION
The default configuration contains a main firewall and assumes there is
an resource ownermap present for this firewall.
This is not always the case.