### PR TITLE
Add owners functionality

### DIFF
--- a/src/Event/AuthenticateUserEvent.php
+++ b/src/Event/AuthenticateUserEvent.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 namespace ConnectHolland\UserBundle\Event;
 
 use ConnectHolland\UserBundle\Entity\UserInterface;
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\EventDispatcher\Event;
 
 final class AuthenticateUserEvent extends /* @scrutinizer ignore-deprecated */ Event implements AuthenticateUserEventInterface
 {

--- a/src/Event/PasswordResetFailedEvent.php
+++ b/src/Event/PasswordResetFailedEvent.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace ConnectHolland\UserBundle\Event;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
 
 class PasswordResetFailedEvent extends /* @scrutinizer ignore-deprecated */ Event implements ResponseEventInterface, PasswordResetFailedEventInterface
 {

--- a/src/Event/PostRegistrationEvent.php
+++ b/src/Event/PostRegistrationEvent.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace ConnectHolland\UserBundle\Event;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
 
 class PostRegistrationEvent extends /* @scrutinizer ignore-deprecated */ Event implements PostRegistrationEventInterface, ResponseEventInterface
 {

--- a/src/Event/UserNotFoundEvent.php
+++ b/src/Event/UserNotFoundEvent.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace ConnectHolland\UserBundle\Event;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
 
 class UserNotFoundEvent extends /* @scrutinizer ignore-deprecated */ Event implements UserNotFoundEventInterface, ResponseEventInterface
 {

--- a/src/EventSubscriber/Doctrine/OwnableSubscriber.php
+++ b/src/EventSubscriber/Doctrine/OwnableSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\EventSubscriber\Doctrine;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use ConnectHolland\UserBundle\Security\Ownable;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class OwnableSubscriber implements EventSubscriber
+{
+    /**
+     * @var TokenStorageInterface|null
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage = null)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::prePersist,
+            Events::preUpdate,
+        ];
+    }
+
+    public function preUpdate(LifecycleEventArgs $args): void
+    {
+        $entity = $args->getEntity();
+        $user   = null;
+
+        if ($this->tokenStorage !== null && $this->tokenStorage->getToken() !== null) {
+            $user = $this->tokenStorage->getToken()->getUser();
+        }
+
+        if ($entity instanceof Ownable === false) {
+            return;
+        }
+
+        if ($entity->getOwners()->isEmpty() && $user instanceof UserInterface) {
+            $entity->addOwner($user);
+        }
+    }
+
+    public function prePersist(LifecycleEventArgs $args): void
+    {
+        $this->preUpdate($args);
+    }
+}

--- a/src/EventSubscriber/FlashSubscriber.php
+++ b/src/EventSubscriber/FlashSubscriber.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 namespace ConnectHolland\UserBundle\EventSubscriber;
 
 use ConnectHolland\UserBundle\UserBundleEvents;
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FlashSubscriber implements EventSubscriberInterface

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -187,3 +187,15 @@ services:
         arguments:
             $client: '@httplug.client'
             $logger: '@logger'
+
+    ConnectHolland\UserBundle\Security\Voter\Owner:
+        arguments:
+            $decisionManager: '@security.access.decision_manager'
+        tags:
+            - { name: 'security.voter' }
+
+    ConnectHolland\UserBundle\EventSubscriber\Doctrine\OwnableSubscriber:
+        arguments:
+            $tokenStorage: '@security.token_storage'
+        tags:
+            - { name: 'doctrine.event_subscriber' }

--- a/src/Security/Ownable.php
+++ b/src/Security/Ownable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Security;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use Doctrine\Common\Collections\Collection;
+
+interface Ownable
+{
+    public function getOwners(): Collection;
+
+    public function addOwner(UserInterface $owner): void;
+}

--- a/src/Security/Traits/OwnableEntityTrait.php
+++ b/src/Security/Traits/OwnableEntityTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Security\Traits;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+trait OwnableEntityTrait
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="ConnectHolland\UserBundle\Entity\User")
+     * @ORM\JoinColumn(nullable=true)
+     *
+     * @var ConnectHolland\UserBundle\Entity\User|null
+     */
+    protected $owner;
+
+    public function getOwner(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setOwner(?UserInterface $owner): self
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getOwners(): Collection
+    {
+        $owners = new ArrayCollection();
+        if ($this->owner !== null) {
+            $owners->add($this->owner);
+        }
+
+        return $owners;
+    }
+
+    public function addOwner(UserInterface $owner): void
+    {
+        $this->setOwner($owner);
+    }
+}

--- a/src/Security/Voter/Owner.php
+++ b/src/Security/Voter/Owner.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Security\Voter;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use ConnectHolland\UserBundle\Security\Ownable;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class Owner extends Voter
+{
+    /**
+     * @var string
+     */
+    const VIEW = 'VIEW';
+
+    /**
+     * @var string
+     */
+    const EDIT = 'EDIT';
+
+    /**
+     * @var string
+     */
+    const CREATE = 'CREATE';
+
+    /**
+     * @var string
+     */
+    const DELETE = 'DELETE';
+
+    /**
+     * @var array<string>
+     */
+    protected $attributes = [self::VIEW, self::EDIT, self::CREATE, self::DELETE];
+
+    /**
+     * @var array<string>
+     */
+    protected $roles = ['ROLE_USER'];
+
+    /**
+     * @var AccessDecisionManagerInterface
+     */
+    private $decisionManager;
+
+    public function __construct(AccessDecisionManagerInterface $decisionManager)
+    {
+        $this->decisionManager = $decisionManager;
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed  $subject
+     */
+    protected function supports($attribute, $subject): bool
+    {
+        // if the attribute isn't one we support, return false
+        if (!in_array($attribute, $this->attributes)) {
+            return false;
+        }
+
+        // only vote on Ownable objects inside this voter
+        if (!$subject instanceof Ownable) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed  $subject
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof UserInterface) {
+            // the user must be logged in; if not, deny access
+            return false;
+        }
+
+        if (!$this->decisionManager->decide($token, $this->roles)) {
+            return false;
+        }
+
+        // you know $subject is a Ownable object, thanks to supports
+        /* @var Ownable $subject */
+
+        switch ($attribute) {
+            case self::CREATE:
+                return $this->canCreate($subject, $user);
+            case self::VIEW:
+                return $this->canView($subject, $user);
+            case self::EDIT:
+                return $this->canEdit($subject, $user);
+            case self::DELETE:
+                return $this->canDelete($subject, $user);
+        }
+
+        throw new \LogicException(sprintf('Unable to handle attribute %2$s. The voter %1$s claimed support for unsupported attribute %2$s', __CLASS__, $attribute));
+    }
+
+    private function canCreate(Ownable $subject, UserInterface $user): bool
+    {
+        return true;
+    }
+
+    private function canView(Ownable $subject, UserInterface $user): bool
+    {
+        // if they can edit, they can view
+        if ($this->canEdit($subject, $user)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    private function canDelete(Ownable $subject, UserInterface $user)
+    {
+        // if they can edit, they can delete
+        if ($this->canEdit($subject, $user)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canEdit(Ownable $subject, UserInterface $user): bool
+    {
+        return $subject->getOwners()->contains($user);
+    }
+}


### PR DESCRIPTION
Add a ownable interface to indicate that an entity can be owned by a
collection of owners.
Add a trait to easily implement the case of an entity with a single owner case.
Add a voter to check if a user has crud permissions based on ownership.
Add a subscriber that assigns ownership when adding/updating an entity
and the entity does not yet have an owner.