### PR TITLE
Fix dev alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-development": "1.0.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
The 1.0-dev branch is pointing to an non-existing dev branch.
Pointing it to master for now.