### PR TITLE
Add profile and account update stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/httplug-bundle": "^1.16",
         "rollerworks/password-strength-validator": "^1.2",
+        "sensio/framework-extra-bundle": "^5.5",
         "stof/doctrine-extensions-bundle": "^1.3",
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/config": "^3.4 || ^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2857e8128ee62481216a295f7613164d",
+    "content-hash": "dc8663f6481dbe0d57cd6869bf9deba9",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2652,6 +2652,84 @@
                 "validator"
             ],
             "time": "2019-12-01T19:22:17+00:00"
+        },
+        {
+            "name": "sensio/framework-extra-bundle",
+            "version": "v5.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
+                "reference": "98f0807137b13d0acfdf3c255a731516e97015de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/98f0807137b13d0acfdf3c255a731516e97015de",
+                "reference": "98f0807137b13d0acfdf3c255a731516e97015de",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "php": ">=7.1.3",
+                "symfony/config": "^4.3|^5.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/framework-bundle": "^4.3|^5.0",
+                "symfony/http-kernel": "^4.3|^5.0"
+            },
+            "conflict": {
+                "doctrine/doctrine-cache-bundle": "<1.3.1"
+            },
+            "require-dev": {
+                "doctrine/doctrine-bundle": "^1.11|^2.0",
+                "doctrine/orm": "^2.5",
+                "nyholm/psr7": "^1.1",
+                "symfony/browser-kit": "^4.3|^5.0",
+                "symfony/dom-crawler": "^4.3|^5.0",
+                "symfony/expression-language": "^4.3|^5.0",
+                "symfony/finder": "^4.3|^5.0",
+                "symfony/monolog-bridge": "^4.0|^5.0",
+                "symfony/monolog-bundle": "^3.2",
+                "symfony/phpunit-bridge": "^4.3.5|^5.0",
+                "symfony/psr-http-message-bridge": "^1.1",
+                "symfony/security-bundle": "^4.3|^5.0",
+                "symfony/twig-bundle": "^4.3|^5.0",
+                "symfony/yaml": "^4.3|^5.0",
+                "twig/twig": "^1.34|^2.4|^3.0"
+            },
+            "suggest": {
+                "symfony/expression-language": "",
+                "symfony/psr-http-message-bridge": "To use the PSR-7 converters",
+                "symfony/security-bundle": ""
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "This bundle provides a way to configure your controllers with annotations",
+            "keywords": [
+                "annotations",
+                "controllers"
+            ],
+            "time": "2019-12-27T08:57:19+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",
@@ -6039,6 +6117,7 @@
                 "json",
                 "normalizer"
             ],
+            "abandoned": "ergebnis/json-normalizer",
             "time": "2019-12-15T14:16:33+00:00"
         },
         {
@@ -9294,6 +9373,7 @@
                 "servicemanager",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-servicemanager",
             "time": "2018-12-22T06:05:09+00:00"
         },
         {
@@ -9340,6 +9420,7 @@
                 "stdlib",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-stdlib",
             "time": "2018-08-28T21:34:05+00:00"
         }
     ],

--- a/src/Controller/Account/AccountController.php
+++ b/src/Controller/Account/AccountController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Controller\Account;
+
+use ConnectHolland\UserBundle\Entity\User;
+use ConnectHolland\UserBundle\Event\UpdateEvent;
+use ConnectHolland\UserBundle\Event\UsernameUpdatedEvent;
+use ConnectHolland\UserBundle\Form\Account\AccountType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Twig\Environment;
+
+/**
+ * @codeCoverageIgnore WIP
+ * @Route({"en": "/account", "nl": "/account"}, name="connectholland_user_account")
+ */
+final class AccountController
+{
+    /**
+     * @var UserPasswordEncoderInterface
+     */
+    private $encoder;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(UserPasswordEncoderInterface $encoder, EventDispatcherInterface $eventDispatcher, Environment $twig)
+    {
+        $this->encoder         = $encoder;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->twig            = $twig;
+    }
+
+    /**
+     * @Route({"en": "/details", "nl": "/gegevens"}, name="_account", methods={"GET", "POST"})
+     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     */
+    public function edit(UserInterface $user, Request $request, FormFactoryInterface $formFactory): Response
+    {
+        /** @var \ConnectHolland\UserBundle\Entity\UserInterface $user */
+        $email = $user->getEmail();
+        $form  = $formFactory->create(AccountType::class);
+        $form->setData($user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $plainPassword = $form->get('plainPassword')->getData();
+
+            if ($email !== $user->getEmail()) {
+                $user->setPasswordRequestToken(bin2hex(random_bytes(32)));
+                $user->setEnabled(false);
+                $event = new UsernameUpdatedEvent($user);
+                $this->eventDispatcher->dispatch($event);
+            }
+
+            if (!empty($plainPassword)) {
+                $password = $this->encoder->encodePassword($user, $plainPassword);
+                $user->setPassword($password);
+            }
+
+            $event = new UpdateEvent($form->getData());
+            $this->eventDispatcher->dispatch($event);
+        }
+
+        return new Response(
+            $this->twig->render(
+                '@ConnecthollandUser/forms/account/account.html.twig',
+                [
+                    'form' => $form->createView(),
+                ]
+            )
+        );
+    }
+}

--- a/src/Controller/Account/ProfileController.php
+++ b/src/Controller/Account/ProfileController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Controller\Account;
+
+use ConnectHolland\UserBundle\Entity\User;
+use ConnectHolland\UserBundle\Event\UpdateEvent;
+use ConnectHolland\UserBundle\Form\Account\ProfileType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
+
+/**
+ * @codeCoverageIgnore WIP
+ * @Route({"en": "/account", "nl": "/account"}, name="connectholland_user_account")
+ */
+final class ProfileController
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, Environment $twig)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->twig            = $twig;
+    }
+
+    /**
+     * @Route({"en": "/profile", "nl": "/profiel"}, name="_profile", methods={"GET", "POST"})
+     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     */
+    public function edit(Request $request, FormFactoryInterface $formFactory): Response
+    {
+        $form = $formFactory->create(ProfileType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new UpdateEvent($form->getData());
+            $this->eventDispatcher->dispatch($event);
+        }
+
+        return new Response(
+            $this->twig->render(
+                '@ConnecthollandUser/forms/account/profile.html.twig',
+                [
+                    'form' => $form->createView(),
+                ]
+            )
+        );
+    }
+}

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -72,7 +72,7 @@ final class RegistrationController
     }
 
     /**
-     * @Route("/registreren", name="connectholland_user_registration", methods={"GET", "POST"})
+     * @Route({"en": "/register", "nl": "/registreren"}, name="connectholland_user_registration", methods={"GET", "POST"})
      */
     public function register(Request $request, FormFactoryInterface $formFactory): Response
     {

--- a/src/Controller/ResetController.php
+++ b/src/Controller/ResetController.php
@@ -76,7 +76,7 @@ final class ResetController
     }
 
     /**
-     * @Route("/wachtwoord-vergeten", name="connectholland_user_reset", methods={"GET", "POST"})
+     * @Route({"en": "/password-reset", "nl": "/wachtwoord-vergeten"}, name="connectholland_user_reset", methods={"GET", "POST"})
      */
     public function reset(Request $request, FormFactoryInterface $formFactory): Response
     {

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -44,7 +44,7 @@ final class SecurityController
     }
 
     /**
-     * @Route("/inloggen", name="connectholland_user_login", methods={"GET", "POST"})
+     * @Route({"en": "/login", "nl": "/inloggen"}, name="connectholland_user_login", methods={"GET", "POST"})
      */
     public function __invoke(): Response
     {

--- a/src/Event/UpdateEvent.php
+++ b/src/Event/UpdateEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Event;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class UpdateEvent extends GenericEvent
+{
+}

--- a/src/Event/UsernameUpdatedEvent.php
+++ b/src/Event/UsernameUpdatedEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Event;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class UsernameUpdatedEvent extends GenericEvent
+{
+}

--- a/src/EventSubscriber/UpdatePersistSubscriber.php
+++ b/src/EventSubscriber/UpdatePersistSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\EventSubscriber;
+
+use ConnectHolland\UserBundle\Event\UpdateEvent;
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class UpdatePersistSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    public function __construct(RegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UpdateEvent::class => 'persistEntity',
+        ];
+    }
+
+    public function persistEntity(UpdateEvent $event): void
+    {
+        $data = $event->getSubject();
+        $this->saveData($data);
+    }
+
+    private function saveData($data): void
+    {
+        $entityClass = ClassUtils::getClass($data); // get correct class, even for proxy classes
+
+        /** @var \Doctrine\Persistence\ObjectManager $entityManager */
+        $entityManager = $this->registry->getManagerForClass($entityClass);
+        $entityManager->persist($data);
+        $entityManager->flush();
+    }
+}

--- a/src/EventSubscriber/UsernameUpdatedSubscriber.php
+++ b/src/EventSubscriber/UsernameUpdatedSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\EventSubscriber;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use ConnectHolland\UserBundle\Event\UsernameUpdatedEvent;
+use ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class UsernameUpdatedSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ValidateUsernameEmail
+     */
+    private $email;
+
+    public function __construct(ValidateUsernameEmail $email)
+    {
+        $this->email = $email;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            UsernameUpdatedEvent::class => 'createUsernameUpdateRequest',
+        ];
+    }
+
+    public function createUsernameUpdateRequest(UsernameUpdatedEvent $event): void
+    {
+        /** @var UserInterface $user */
+        $user = $event->getSubject();
+        if ($user->isEnabled() === false) {
+            $this->email->send($user);
+        }
+    }
+}

--- a/src/Form/Account/AccountType.php
+++ b/src/Form/Account/AccountType.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Form\Account;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use ConnectHolland\UserBundle\Security\PasswordConstraints;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType as BasePasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @codeCoverageIgnore Contains no functionality as there is no buildForm, only configure methods are used.
+ */
+class AccountType extends AbstractType
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $doctrine;
+
+    /**
+     * @var PasswordConstraints
+     */
+    private $passwordConstraints;
+
+    public function __construct(RegistryInterface $doctrine, PasswordConstraints $passwordConstraints)
+    {
+        $this->doctrine            = $doctrine;
+        $this->passwordConstraints = $passwordConstraints;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'email',
+                EmailType::class,
+                [
+                    'label'              => 'connectholland_user.registration.email',
+                    'translation_domain' => 'ConnecthollandUserBundle',
+                    'constraints'        => [
+                        new NotBlank([
+                            'message' => 'connectholland_user.validation.registration.email.blank',
+                        ]),
+                    ],
+                ]
+            )
+            ->add(
+                'plainPassword',
+                RepeatedType::class,
+                [
+                    'type'          => BasePasswordType::class,
+                    'required'      => false,
+                    'mapped'        => false,
+                    'first_options' => [
+                        'label'       => 'connectholland_user.reset.new_password.password',
+                        'constraints' => $this->getPasswordConstraints(),
+                    ],
+                    'second_options' => [
+                        'label' => 'connectholland_user.reset.new_password.password_repeat',
+                    ],
+                    'invalid_message'    => 'connectholland_user.validation.reset.new_password.password.repeat_invalid',
+                    'translation_domain' => 'ConnecthollandUserBundle',
+                ]
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class'         => $this->doctrine->getRepository(UserInterface::class)->getClassName(),
+            'translation_domain' => 'ConnecthollandUserBundle',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return '';
+    }
+
+    /**
+     * Get all the constraints for password without any NotBlank constraint.
+     * Password can be empty in this form, because the password field will be ignored unless it is filled in.
+     */
+    private function getPasswordConstraints(): array
+    {
+        $constraints = $this->passwordConstraints->getConstraints();
+        foreach ($constraints as $key => $value) {
+            if ($value instanceof NotBlank) {
+                unset($constraints[$key]);
+            }
+        }
+
+        return $constraints;
+    }
+}

--- a/src/Form/Account/ProfileType.php
+++ b/src/Form/Account/ProfileType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Form\Account;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @codeCoverageIgnore Contains no functionality as there is no buildForm, only configure methods are used.
+ */
+class ProfileType extends AbstractType
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $doctrine;
+
+    public function __construct(RegistryInterface $doctrine)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class'         => $this->doctrine->getRepository(UserInterface::class)->getClassName(),
+            'translation_domain' => 'ConnecthollandUserBundle',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return '';
+    }
+}

--- a/src/Mailer/ValidateUsernameEmail.php
+++ b/src/Mailer/ValidateUsernameEmail.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Mailer;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use Symfony\Component\HttpKernel\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @codeCoverageIgnore WIP
+ */
+final class ValidateUsernameEmail extends BaseEmail
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var UriSigner
+     */
+    private $uriSigner;
+
+    public function __construct(RouterInterface $router, UriSigner $uriSigner)
+    {
+        $this->router    = $router;
+        $this->uriSigner = $uriSigner;
+    }
+
+    public function send(UserInterface $user): \Swift_Message
+    {
+        $link = $this->router->generate('connectholland_user_registration_confirm', ['token' => $user->getPasswordRequestToken(), 'email' => $user->getEmail()], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        return $this->mailer->createMessageAndSend(
+            'validate-username',
+            $user->getEmail(),
+            [
+                'user' => $user,
+                'link' => $this->uriSigner->sign($link),
+            ]
+        );
+    }
+}

--- a/src/Resources/config/routing.yaml
+++ b/src/Resources/config/routing.yaml
@@ -14,5 +14,13 @@ connectholland_user_reset:
     resource: '@ConnecthollandUserBundle/Controller/ResetController.php'
     type: annotation
 
+connectholland_user_account_profile:
+    resource: '@ConnecthollandUserBundle/Controller/Account/ProfileController.php'
+    type: annotation
+
+connectholland_user_account_detail:
+    resource: '@ConnecthollandUserBundle/Controller/Account/AccountController.php'
+    type: annotation
+
 connectholland_user_logout:
     path: /logout

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -28,6 +28,11 @@ services:
             - '@router'
             - '@Symfony\Component\HttpKernel\UriSigner'
 
+    ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail:
+        arguments:
+            - '@router'
+            - '@Symfony\Component\HttpKernel\UriSigner'
+
     ConnectHolland\UserBundle\Mailer\ResetEmail:
         arguments:
             - '@router'
@@ -47,6 +52,21 @@ services:
             - '@session'
             - '@event_dispatcher'
             - '@router'
+            - '@twig'
+        tags:
+            - { name: controller.service_arguments }
+
+    ConnectHolland\UserBundle\Controller\Account\ProfileController:
+        arguments:
+            - '@event_dispatcher'
+            - '@twig'
+        tags:
+            - { name: controller.service_arguments }
+
+    ConnectHolland\UserBundle\Controller\Account\AccountController:
+        arguments:
+            - '@security.user_password_encoder.generic'
+            - '@event_dispatcher'
             - '@twig'
         tags:
             - { name: controller.service_arguments }
@@ -134,6 +154,19 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ConnectHolland\UserBundle\EventSubscriber\UpdatePersistSubscriber:
+        arguments:
+            $registry: '@doctrine'
+        tags:
+            - { name: 'kernel.event_subscriber' }
+
+    ConnectHolland\UserBundle\EventSubscriber\UsernameUpdatedSubscriber:
+        arguments:
+            - '@ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail'
+            - '@Doctrine\Common\Persistence\ManagerRegistry'
+        tags:
+            - { name: 'kernel.event_subscriber' }
+
     ConnectHolland\UserBundle\Security\OAuthUserProvider:
         arguments:
             $doctrine: '@Doctrine\Common\Persistence\ManagerRegistry'
@@ -153,6 +186,21 @@ services:
     ConnectHolland\UserBundle\Form\RegistrationType:
         public: true
         arguments:
+            $doctrine: '@Doctrine\Common\Persistence\ManagerRegistry'
+        tags:
+            - { name: 'form.type' }
+
+    ConnectHolland\UserBundle\Form\Account\ProfileType:
+        public: true
+        arguments:
+            $doctrine: '@Doctrine\Common\Persistence\ManagerRegistry'
+        tags:
+            - { name: 'form.type' }
+
+    ConnectHolland\UserBundle\Form\Account\AccountType:
+        public: true
+        arguments:
+            $passwordConstraints: '@ConnectHolland\UserBundle\Security\PasswordConstraints'
             $doctrine: '@Doctrine\Common\Persistence\ManagerRegistry'
         tags:
             - { name: 'form.type' }

--- a/src/Resources/translations/ConnecthollandUserBundle.en.yml
+++ b/src/Resources/translations/ConnecthollandUserBundle.en.yml
@@ -18,6 +18,12 @@ connectholland_user:
         submit: 'Register'
         terms: 'Terms'
         title: 'Register'
+    account:
+        submit: 'Save'
+        account:
+            title: 'Edit account'
+        profile:
+            title: 'Edit profile'
     reset:
         request:
             email: 'Email address'

--- a/src/Resources/translations/ConnecthollandUserBundle.nl.yml
+++ b/src/Resources/translations/ConnecthollandUserBundle.nl.yml
@@ -18,6 +18,12 @@ connectholland_user:
         submit: 'Registreren'
         terms: 'Voorwaarden'
         title: 'Registreren'
+    account:
+        submit: 'Opslaan'
+        account:
+            title: 'Account aanpassen'
+        profile:
+            title: 'Profiel aanpassen'
     reset:
         request:
             email: 'E-mailadres'
@@ -38,3 +44,15 @@ connectholland_user:
             submit: 'Inloggen'
             title: 'Inloggen'
             username: 'Gebruikersnaam'
+    emails:
+        registration:
+            title: 'Registratie'
+            body: ''
+            confirm: 'Bevestig registratie'
+
+        revalidate:
+            title: 'Bevestig gebruikersnaam'
+            body: |
+                Je hebt een nieuwe gebruikersnaam (%username%) aangevraagd.
+                Je kunt pas weer inloggen wanneer je gebruikersnaam is bevestigd.
+            confirm: 'Bevestig nieuwe gebruikersnaam'

--- a/src/Resources/views/emails/registration.html.twig
+++ b/src/Resources/views/emails/registration.html.twig
@@ -1,8 +1,10 @@
 {% extends 'emails/base.html.twig' %}
+{% trans_default_domain 'ConnecthollandUserBundle' %}
 
-{% block connectholland_user_email_title %}Registration{% endblock %}
+{% block connectholland_user_email_title %}{{ 'connectholland_user.emails.registration.title'|trans }}{% endblock %}
 
 {% block connectholland_user_email_content %}
-    <h1>Registration</h1>
-    <a href='{{ link }}'>Confirm registation</a>
+    <h1>{{ 'connectholland_user.emails.registration.title'|trans }}</h1>
+    <p>{{ 'connectholland_user.emails.registration.body'|trans }}</p>
+    <a href='{{ link }}'>{{ 'connectholland_user.emails.registration.confirm'|trans }}</a>
 {% endblock %}

--- a/src/Resources/views/emails/validate-username.html.twig
+++ b/src/Resources/views/emails/validate-username.html.twig
@@ -1,0 +1,10 @@
+{% extends 'emails/base.html.twig' %}
+{% trans_default_domain 'ConnecthollandUserBundle' %}
+
+{% block connectholland_user_email_title %}{{ 'connectholland_user.emails.revalidate.title'|trans }}{% endblock %}
+
+{% block connectholland_user_email_content %}
+    <h1>{{ 'connectholland_user.emails.revalidate.title'|trans }}</h1>
+    <p>{{ 'connectholland_user.emails.revalidate.body'|trans({'%username%': user.username})|nl2br}}</p>
+    <a href='{{ link }}'>{{ 'connectholland_user.emails.revalidate.confirm'|trans }}</a>
+{% endblock %}

--- a/src/Resources/views/forms/account/account.html.twig
+++ b/src/Resources/views/forms/account/account.html.twig
@@ -1,0 +1,14 @@
+{% extends '@ConnecthollandUser/base.html.twig' %}
+
+{% trans_default_domain 'ConnecthollandUserBundle' %}
+
+{% block connectholland_user_content %}
+    <h1>{{ 'connectholland_user.account.account.title'|trans }}</h1>
+
+    {{ form_start(form) }}
+        {% block connectholland_user_account_account_form_fields %}
+            {{ form_widget(form) }}
+        {% endblock %}
+        <button type="submit" class="btn">{{ 'connectholland_user.account.submit'|trans }}</button>
+    {{ form_end(form) }}
+{% endblock %}

--- a/src/Resources/views/forms/account/profile.html.twig
+++ b/src/Resources/views/forms/account/profile.html.twig
@@ -1,0 +1,14 @@
+{% extends '@ConnecthollandUser/base.html.twig' %}
+
+{% trans_default_domain 'ConnecthollandUserBundle' %}
+
+{% block connectholland_user_content %}
+    <h1>{{ 'connectholland_user.account.profile.title'|trans }}</h1>
+
+    {{ form_start(form) }}
+        {% block connectholland_user_account_profile_form_fields %}
+            {{ form_widget(form) }}
+        {% endblock %}
+        <button type="submit" class="btn">{{ 'connectholland_user.account.submit'|trans }}</button>
+    {{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
Add out of the box form stubs/routes for updating user account
(username/password) and additional profile information (like name,
address etc.).

Fields can be added by using a form extension.

| Production Changes            | From | To     | Compare |
|-------------------------------|------|--------|---------|
| sensio/framework-extra-bundle | NEW  | v5.5.3 |         |

Example of the default account form:

![image](https://user-images.githubusercontent.com/8127722/73260510-53011300-41ca-11ea-8381-8bf58c842811.png)
