### PR TITLE
Logout user after username change

### DIFF
--- a/src/Controller/Account/AccountController.php
+++ b/src/Controller/Account/AccountController.php
@@ -70,6 +70,7 @@ final class AccountController
                 $user->setPasswordRequestToken(bin2hex(random_bytes(32)));
                 $user->setEnabled(false);
                 $event = new UsernameUpdatedEvent($user);
+                $event->setArgument('request', $request);
                 $this->eventDispatcher->dispatch($event);
             }
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -163,7 +163,7 @@ services:
     ConnectHolland\UserBundle\EventSubscriber\UsernameUpdatedSubscriber:
         arguments:
             - '@ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail'
-            - '@Doctrine\Common\Persistence\ManagerRegistry'
+            - '@security.token_storage'
         tags:
             - { name: 'kernel.event_subscriber' }
 

--- a/tests/EventSubscriber/UsernameUpdatedSubscriberTest.php
+++ b/tests/EventSubscriber/UsernameUpdatedSubscriberTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\Tests\EventSubscriber;
+
+use ConnectHolland\UserBundle\Entity\UserInterface;
+use ConnectHolland\UserBundle\Event\UsernameUpdatedEvent;
+use ConnectHolland\UserBundle\EventSubscriber\UsernameUpdatedSubscriber;
+use ConnectHolland\UserBundle\Mailer\MailerInterface;
+use ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\UriSigner;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Test the username updated subscriber.
+ *
+ * @coversDefaultClass \ConnectHolland\UserBundle\EventSubscriber\UsernameUpdatedSubscriber
+ */
+class UsernameUpdatedSubscriberTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     */
+    public function testCanBeInstantiaded(): void
+    {
+        [$subject] = $this->getTestClass();
+        $this->assertInstanceOf(UsernameUpdatedSubscriber::class, $subject, 'Asserting that the class can be instantiated.');
+    }
+
+    /**
+     * @covers ::createUsernameUpdateRequest
+     */
+    public function testWhenTheUsernameChangesTheUserHasToRevalidateTheUsername(): void
+    {
+        [$subject, $email, $tokenStorage, $mailer, $router, $uriSigner] = $this->getTestClass();
+        $user                                                           = $this->createMock(UserInterface::class);
+        $event                                                          = new UsernameUpdatedEvent($user);
+        $request                                                        = $this->createMock(Request::class);
+        $session                                                        = $this->createMock(SessionInterface::class);
+
+        $user
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->willReturn(false)
+        ;
+
+        $request
+            ->expects($this->once())
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $mailer
+            ->expects($this->once())
+            ->method('createMessageAndSend')
+        ;
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('setToken')
+            ->with(null)
+        ;
+        $session
+            ->expects($this->once())
+            ->method('invalidate')
+        ;
+
+        $event->setArgument('request', $request);
+
+        $subject->createUsernameUpdateRequest($event);
+    }
+
+    /**
+     * @covers ::getSubscribedEvents
+     */
+    public function testUsernameUpdatedSubscriberSubscribesToTheUsernameUpdatedEvent(): void
+    {
+        [$subject] = $this->getTestClass();
+        $this->assertArrayHasKey(UsernameUpdatedEvent::class, $subject->getSubscribedEvents(), 'Asserting that the subscriber subscribes to the UsernameUpdatedEvent.');
+    }
+
+    public function getTestClass(): array
+    {
+        $mailer       = $this->createMock(MailerInterface::class);
+        $router       = $this->createMock(RouterInterface::class);
+        $uriSigner    = $this->createMock(UriSigner::class);
+        $email        = new ValidateUsernameEmail($router, $uriSigner);
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+
+        $email->setMailer($mailer);
+
+        return [new UsernameUpdatedSubscriber($email, $tokenStorage), $email, $tokenStorage, $mailer, $router, $uriSigner];
+    }
+}


### PR DESCRIPTION
When the username is changed, the user receives an e-mail to validate
the new username. Until the username is validated the user should not be
able to use the account. Therefore logging out the user on user name
change.

What is still needed is a clear explanation for the user, explaining what the impact of changing the username will be.

![image](https://user-images.githubusercontent.com/8127722/74422777-6dd0ba00-4e4f-11ea-843a-b4d55e9fc281.png)
