### PR TITLE
Check for response negotiation bundle

### DIFF
--- a/src/DependencyInjection/ConnecthollandUserExtension.php
+++ b/src/DependencyInjection/ConnecthollandUserExtension.php
@@ -52,6 +52,10 @@ class ConnecthollandUserExtension extends Extension implements ExtensionInterfac
         $this->prependApiPlatformConfiguration($container);
         $this->prependDoctrineConfiguration($container);
         $this->prependHwiOAuthConfiguration($container);
+
+        if (!$container->hasExtension('response_content_negotiation')) {
+            throw new MissingResponseContentNegotiationBundleException();
+        }
     }
 
     private function prependHwiOAuthConfiguration(ContainerBuilder $container): void

--- a/src/DependencyInjection/MissingResponseContentNegotiationBundleException.php
+++ b/src/DependencyInjection/MissingResponseContentNegotiationBundleException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the user bundle package.
+ * (c) Connect Holland.
+ */
+
+namespace ConnectHolland\UserBundle\DependencyInjection;
+
+class MissingResponseContentNegotiationBundleException extends \RuntimeException
+{
+    protected $message = 'The response content negotiation bundle is not enabled. Add \'GisoStallenberg\Bundle\ResponseContentNegotiationBundle\GisoStallenbergResponseContentNegotiationBundle\' to the enabled bundles.';
+}


### PR DESCRIPTION
Throw an exception if the response negotiation bundle is not enabled.
In the message describe that the response negotiation bundle should be
enabled and how.