### PR TITLE
Add parameters for confirm and remove unsupported property attributes

### DIFF
--- a/src/ApiPlatform/Message/Account.php
+++ b/src/ApiPlatform/Message/Account.php
@@ -72,7 +72,6 @@ class Account
      *    attributes = {
      *        "swagger_context" = {
      *           "type"= "object",
-     *           "required" = true,
      *           "properties" = {
      *               "first" = {
      *                   "type"     = "string",

--- a/src/ApiPlatform/Message/Account.php
+++ b/src/ApiPlatform/Message/Account.php
@@ -75,14 +75,10 @@ class Account
      *           "required" = true,
      *           "properties" = {
      *               "first" = {
-     *                   "name"     = "first",
      *                   "type"     = "string",
-     *                   "required" = true
      *               },
      *               "second" = {
-     *                   "name"     = "second",
      *                   "type"     = "string",
-     *                   "required" = true
      *               }
      *           }
      *        }

--- a/src/ApiPlatform/Message/Confirm.php
+++ b/src/ApiPlatform/Message/Confirm.php
@@ -46,9 +46,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *                  "tags"            = {"Register"},
  *                  "responses"       = {
  *                      "200" = {
- *                          "description" = "The user e-mail is confirmed succesfully",
- *                          "schema"      = {
- *                          }
+ *                          "description" = "The user e-mail is confirmed succesfully"
  *                      },
  *                  },
  *              },

--- a/src/ApiPlatform/Message/Confirm.php
+++ b/src/ApiPlatform/Message/Confirm.php
@@ -29,6 +29,20 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *              "route_name"      = "connectholland_user_registration_confirm.api",
  *              "swagger_context" = {
  *                  "summary"         = "Confirm user e-mail with the API.",
+ *                  "parameters" = {
+ *                      {
+ *                          "name" = "email",
+ *                          "in" = "path",
+ *                          "required" = true,
+ *                          "type" = "string"
+ *                      },
+ *                      {
+ *                          "name" = "token",
+ *                          "in" = "path",
+ *                          "required" = true,
+ *                          "type" = "string"
+ *                      },
+ *                  },
  *                  "tags"            = {"Register"},
  *                  "responses"       = {
  *                      "200" = {


### PR DESCRIPTION
Current generated api spec breaks with a validator

- name & required are not allowed in properties
- add parameters for confirm get action
- response cannot be an empty schema field