### PR TITLE
Use api validation url for api registrations

### DIFF
--- a/src/Mailer/ValidateUsernameEmail.php
+++ b/src/Mailer/ValidateUsernameEmail.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace ConnectHolland\UserBundle\Mailer;
 
 use ConnectHolland\UserBundle\Entity\UserInterface;
+use GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\NegotiatorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -29,15 +31,28 @@ final class ValidateUsernameEmail extends BaseEmail
      */
     private $uriSigner;
 
-    public function __construct(RouterInterface $router, UriSigner $uriSigner)
+    /**
+     * @var NegotiatorInterface
+     */
+    private $negotiator;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(RouterInterface $router, UriSigner $uriSigner, NegotiatorInterface $negotiator, RequestStack $requestStack)
     {
-        $this->router    = $router;
-        $this->uriSigner = $uriSigner;
+        $this->router       = $router;
+        $this->uriSigner    = $uriSigner;
+        $this->negotiator   = $negotiator;
+        $this->requestStack = $requestStack;
     }
 
     public function send(UserInterface $user): \Swift_Message
     {
-        $link = $this->router->generate('connectholland_user_registration_confirm', ['token' => $user->getPasswordRequestToken(), 'email' => $user->getEmail()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $route = $this->getRoute();
+        $link  = $this->router->generate($route, ['token' => $user->getPasswordRequestToken(), 'email' => $user->getEmail()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->mailer->createMessageAndSend(
             'validate-username',
@@ -47,5 +62,15 @@ final class ValidateUsernameEmail extends BaseEmail
                 'link' => $this->uriSigner->sign($link),
             ]
         );
+    }
+
+    private function getRoute(): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request !== null && $this->negotiator->getResult($request) === 'json') {
+            return 'connectholland_user_registration_confirm.api';
+        }
+
+        return 'connectholland_user_registration_confirm';
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -27,12 +27,16 @@ services:
         arguments:
             - '@router'
             - '@Symfony\Component\HttpKernel\UriSigner'
+            - '@GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\FormatNegotiator'
+            - '@request_stack'
     ConnectHolland\UserBundle\Mailer\RegistrationEmailInterface: '@ConnectHolland\UserBundle\Mailer\RegistrationEmail'
 
     ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail:
         arguments:
             - '@router'
             - '@Symfony\Component\HttpKernel\UriSigner'
+            - '@GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\FormatNegotiator'
+            - '@request_stack'
 
     ConnectHolland\UserBundle\Mailer\ResetEmail:
         arguments:

--- a/tests/EventSubscriber/UsernameUpdatedSubscriberTest.php
+++ b/tests/EventSubscriber/UsernameUpdatedSubscriberTest.php
@@ -14,8 +14,10 @@ use ConnectHolland\UserBundle\Event\UsernameUpdatedEvent;
 use ConnectHolland\UserBundle\EventSubscriber\UsernameUpdatedSubscriber;
 use ConnectHolland\UserBundle\Mailer\MailerInterface;
 use ConnectHolland\UserBundle\Mailer\ValidateUsernameEmail;
+use GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\NegotiatorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\RouterInterface;
@@ -94,7 +96,9 @@ class UsernameUpdatedSubscriberTest extends TestCase
         $mailer       = $this->createMock(MailerInterface::class);
         $router       = $this->createMock(RouterInterface::class);
         $uriSigner    = $this->createMock(UriSigner::class);
-        $email        = new ValidateUsernameEmail($router, $uriSigner);
+        $negotiator   = $this->createMock(NegotiatorInterface::class);
+        $stack        = $this->createMock(RequestStack::class);
+        $email        = new ValidateUsernameEmail($router, $uriSigner, $negotiator, $stack);
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
 
         $email->setMailer($mailer);


### PR DESCRIPTION
When registration happens through the api, the link in the api should be
signed as api url.