### PR TITLE
Fix name of refresh token

### DIFF
--- a/src/ApiPlatform/Refresh/Message/Refresh.php
+++ b/src/ApiPlatform/Refresh/Message/Refresh.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace ConnectHolland\UserBundle\ApiPlatform\Refresh\Message;
 
 use ApiPlatform\Core\Annotation as Api;
+use Symfony\Component\Serializer\Annotation\SerializedName;
 
 /**
  * Authentication resource.
@@ -71,6 +72,8 @@ class Refresh
 {
     /**
      * @var string
+     *
+     * @SerializedName("refresh_token")
      */
     public $refreshToken;
 }


### PR DESCRIPTION
The refresh token endpoints expects data to be as {"refresh_token": "XXX"}.  Because the variable name was camelCase API Platform showed the expected key to be "refreshToken". This PR straightens this out