### PR TITLE
Add identifiers to api messages

### DIFF
--- a/src/ApiPlatform/Message/Account.php
+++ b/src/ApiPlatform/Message/Account.php
@@ -64,6 +64,7 @@ class Account
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $email;
 

--- a/src/ApiPlatform/Message/Authenticate.php
+++ b/src/ApiPlatform/Message/Authenticate.php
@@ -71,6 +71,7 @@ class Authenticate
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $username;
 

--- a/src/ApiPlatform/Message/Confirm.php
+++ b/src/ApiPlatform/Message/Confirm.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace ConnectHolland\UserBundle\ApiPlatform\Message;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation as Api;
 
 /**
  * User confirmation resource.
  *
- * @ApiResource(
+ * @Api\ApiResource(
  *     attributes={"pagination_enabled"=false},
  *     messenger=true,
  *     collectionOperations={
@@ -59,6 +59,7 @@ class Confirm
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $email;
 

--- a/src/ApiPlatform/Message/Profile.php
+++ b/src/ApiPlatform/Message/Profile.php
@@ -45,6 +45,7 @@ class Profile
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $email;
 

--- a/src/ApiPlatform/Message/Register.php
+++ b/src/ApiPlatform/Message/Register.php
@@ -56,6 +56,7 @@ class Register
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $email;
 

--- a/src/ApiPlatform/Message/Reset.php
+++ b/src/ApiPlatform/Message/Reset.php
@@ -53,6 +53,7 @@ class Reset
 {
     /**
      * @var string
+     * @Api\ApiProperty(identifier=true)
      */
     public $username;
 }

--- a/src/ApiPlatform/Refresh/Message/Refresh.php
+++ b/src/ApiPlatform/Refresh/Message/Refresh.php
@@ -73,6 +73,7 @@ class Refresh
     /**
      * @var string
      *
+     * @Api\ApiProperty(identifier=true)
      * @SerializedName("refresh_token")
      */
     public $refreshToken;


### PR DESCRIPTION
While these api messages are actually invalid and should be replaced with https://api-platform.com/docs/core/openapi/#overriding-the-openapi-specification. The fastest fix for now is adding (fake) identifiers.