### PR TITLE
fix: resolve stale request capture in FrankenPHP worker mode

### DIFF
--- a/src/EventSubscriber/PasswordResetFailedSubscriber.php
+++ b/src/EventSubscriber/PasswordResetFailedSubscriber.php
@@ -14,19 +14,12 @@ use ConnectHolland\UserBundle\UserBundleEvents;
 use GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\NegotiatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class PasswordResetFailedSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var Request|null
-     */
-    private $request;
-
-    public function __construct(private readonly NegotiatorInterface $negotiator, RequestStack $requestStack)
+    public function __construct(private readonly NegotiatorInterface $negotiator, private readonly RequestStack $requestStack)
     {
-        $this->request    = $requestStack->getCurrentRequest();
     }
 
     /**
@@ -43,7 +36,9 @@ class PasswordResetFailedSubscriber implements EventSubscriberInterface
 
     public function onPostRegistrationEvent(PasswordResetFailedEvent $event): void
     {
-        if ($this->request !== null && $this->negotiator->getResult($this->request) === 'json') {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request !== null && $this->negotiator->getResult($request) === 'json') {
             $response = new JsonResponse(['errors' => ['connectholland_user.password_reset_failed' => 'Resetting the password failed.']], JsonResponse::HTTP_BAD_REQUEST);
             $event->setResponse($response);
         }

--- a/src/EventSubscriber/RegistrationSubscriber.php
+++ b/src/EventSubscriber/RegistrationSubscriber.php
@@ -13,19 +13,12 @@ use ConnectHolland\UserBundle\Event\PostRegistrationEvent;
 use GisoStallenberg\Bundle\ResponseContentNegotiationBundle\Negotiation\NegotiatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class RegistrationSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var Request|null
-     */
-    private $request;
-
-    public function __construct(private readonly NegotiatorInterface $negotiator, RequestStack $requestStack)
+    public function __construct(private readonly NegotiatorInterface $negotiator, private readonly RequestStack $requestStack)
     {
-        $this->request    = $requestStack->getCurrentRequest();
     }
 
     /**
@@ -42,7 +35,9 @@ class RegistrationSubscriber implements EventSubscriberInterface
 
     public function onPostRegistrationEvent(PostRegistrationEvent $event): void
     {
-        if ($this->request !== null && $this->negotiator->getResult($this->request) === 'json') {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request !== null && $this->negotiator->getResult($request) === 'json') {
             $response = new JsonResponse([]);
             $event->setResponse($response);
         }


### PR DESCRIPTION
## Summary
- stop caching the current request in subscriber constructors
- store RequestStack and resolve the current request when handling the event
- apply the fix to both registration and password reset failure subscribers

## Validation
- php -l src/EventSubscriber/RegistrationSubscriber.php
- php -l src/EventSubscriber/PasswordResetFailedSubscriber.php
- php-cs-fixer fix on the two changed subscriber files